### PR TITLE
Update build tools

### DIFF
--- a/Financisto/build.gradle
+++ b/Financisto/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.application'
-apply plugin: 'com.neenbedankt.android-apt'
 
 repositories {
     maven { url "http://repo.commonsware.com.s3.amazonaws.com" }
@@ -48,6 +47,7 @@ android {
 }
 
 def googlePlayVersion = '6.5.87'
+def androidAnnotationVersion = '4.4.0'
 
 dependencies {
 
@@ -77,19 +77,14 @@ dependencies {
     //compile "com.google.android.gms:play-services-appstate:$googlePlayVersion"
     //compile "com.google.android.gms:play-services-wearable:$googlePlayVersion"
     //compile "com.google.android.gms:play-services-all-wear:$googlePlayVersion"
-    apt "org.androidannotations:androidannotations:3.3.2"
-    compile 'org.androidannotations:androidannotations-api:3.3.2'
+
+    annotationProcessor "org.androidannotations:androidannotations:$androidAnnotationVersion"
+    compile "org.androidannotations:androidannotations-api:$androidAnnotationVersion"
+
     compile 'com.commonsware.cwac:wakeful:1.0.5'
     compile 'net.sf.trove4j:trove4j:3.0.3'
     compile 'de.greenrobot:eventbus:2.4.0'
     compile 'com.squareup.okhttp3:okhttp:3.0.0-RC1'
     compile 'com.google.guava:guava:19.0'
     compile fileTree(include: ['**/*.jar'], dir: 'libs')
-}
-
-apt {
-    arguments {
-        androidManifestFile variant.outputs[0].processResources.manifestFile
-        resourcePackageName 'ru.orangesoftware.financisto2'
-    }
 }

--- a/Financisto/build.gradle
+++ b/Financisto/build.gradle
@@ -8,7 +8,7 @@ repositories {
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '23.0.2'
+    buildToolsVersion '26.0.2'
 
 //    compileOptions {
 //        sourceCompatibility JavaVersion.VERSION_1_7

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,5 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+# FIXME: try to enable aapt2
+android.enableAapt2=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 01 20:19:23 SGT 2014
+#Wed Nov 28 19:03:52 CST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Android Studio always complains about old build tool version, this PR tries to update build tools version.

Also, replace apt by annotationProcessor.

It disabled aapt2 due to it is not usable for now.